### PR TITLE
fix: Groups management syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ users:
 
 ```
 
+### User List Structure
+```yaml
+users_group_list:
+  - name: sudo
+  - name: docker
+  - name: temporary
+    state: absent
+```
+
 ## Playbook example
 
 1. Creating a system admin user and a deploy user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,10 +22,9 @@
 
 - name: "Manage groups"
   group:
-    name: "{{ item }}"
+    name: "{{ item.name }}"
     state: "{{ item.state | default('present') }}"
-  loop:
-    - "{{ users_group_list }}"
+  loop: "{{ users_group_list }}"
   when:
     - users_group_list is iterable
     


### PR DESCRIPTION
- Fixes #4. `loop: [ "{{ user_group_list }}" ]` is interpreted as a list with list of groups.
- Defines the group list structure. Previously, if `users_group_list` defined as `['sudo', 'docker']`, then `item.state | default('present')` fallbacks to `present` in any case without possibility to make group `absent`